### PR TITLE
Fix crygen version to `~> 0.5.0`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,4 +11,4 @@ license: MIT
 dependencies:
   crygen:
     github: tamdaz/crygen
-    branch: main
+    version: ~> 0.5.0


### PR DESCRIPTION
Due to breaking changes (https://github.com/tamdaz/crygen/pull/35), the version of crygen is fixed to `~> 0.5.0` instead of retriveing the last change from the `main` branch. This allows to keep the compatibility and make `mcprotocol` operational, if necessary.